### PR TITLE
Add compact option to attributes and serialize_structured_value methods

### DIFF
--- a/lib/structured_params/params.rb
+++ b/lib/structured_params/params.rb
@@ -154,7 +154,8 @@ module StructuredParams
     end
 
     # Serialize structured values
-    #: (untyped, compact: false) -> untyped
+    #: (bool, compact: false) -> untyped
+    #: (bool, compact: true) -> untyped
     def serialize_structured_value(value, compact: false)
       case value
       when Array

--- a/lib/structured_params/params.rb
+++ b/lib/structured_params/params.rb
@@ -73,17 +73,20 @@ module StructuredParams
     end
 
     # Convert structured objects to Hash and get attributes
-    #: (symbolize: true) -> Hash[Symbol, untyped]
-    #: (symbolize: false) -> Hash[String, untyped]
-    def attributes(symbolize: false)
+    #: (symbolize: true, compact: false) -> Hash[Symbol, untyped]
+    #: (symbolize: false, compact: false) -> Hash[String, untyped]
+    #: (symbolize: true, compact: true) -> Hash[Symbol, untyped]
+    #: (symbolize: false, compact: true) -> Hash[String, untyped]
+    def attributes(symbolize: false, compact: false)
       attrs = super()
 
       self.class.structured_attributes.each_key do |name|
         value = attrs[name.to_s]
-        attrs[name.to_s] = serialize_structured_value(value)
+        attrs[name.to_s] = serialize_structured_value(value, compact: compact)
       end
 
-      symbolize ? attrs.deep_symbolize_keys : attrs
+      result = symbolize ? attrs.deep_symbolize_keys : attrs
+      compact ? result.compact : result
     end
 
     private
@@ -151,13 +154,14 @@ module StructuredParams
     end
 
     # Serialize structured values
-    #: (untyped) -> untyped
-    def serialize_structured_value(value)
+    #: (untyped, compact: false) -> untyped
+    def serialize_structured_value(value, compact: false)
       case value
       when Array
-        value.map { |item| item.attributes(symbolize: false) }
+        result = value.map { |item| item.attributes(symbolize: false, compact: compact) }
+        compact ? result.compact : result
       when StructuredParams::Params
-        value.attributes(symbolize: false)
+        value.attributes(symbolize: false, compact: compact)
       else
         value
       end

--- a/sig/structured_params/params.rbs
+++ b/sig/structured_params/params.rbs
@@ -38,10 +38,14 @@ module StructuredParams
     def errors: () -> ::StructuredParams::Errors
 
     # Convert structured objects to Hash and get attributes
-    # : (symbolize: true) -> Hash[Symbol, untyped]
-    # : (symbolize: false) -> Hash[String, untyped]
-    def attributes: (symbolize: true) -> Hash[Symbol, untyped]
-                  | (symbolize: false) -> Hash[String, untyped]
+    # : (symbolize: true, compact: false) -> Hash[Symbol, untyped]
+    # : (symbolize: false, compact: false) -> Hash[String, untyped]
+    # : (symbolize: true, compact: true) -> Hash[Symbol, untyped]
+    # : (symbolize: false, compact: true) -> Hash[String, untyped]
+    def attributes: (symbolize: true, compact: false) -> Hash[Symbol, untyped]
+                  | (symbolize: false, compact: false) -> Hash[String, untyped]
+                  | (symbolize: true, compact: true) -> Hash[Symbol, untyped]
+                  | (symbolize: false, compact: true) -> Hash[String, untyped]
 
     private
 
@@ -70,8 +74,8 @@ module StructuredParams
     def format_error_path: (Symbol, Integer?) -> String
 
     # Serialize structured values
-    # : (untyped) -> untyped
-    def serialize_structured_value: (untyped) -> untyped
+    # : (untyped, compact: false) -> untyped
+    def serialize_structured_value: (untyped, compact: false) -> untyped
 
     # Integrate structured parameter errors into parent errors
     # : (untyped, String) -> void

--- a/sig/structured_params/params.rbs
+++ b/sig/structured_params/params.rbs
@@ -75,7 +75,9 @@ module StructuredParams
 
     # Serialize structured values
     # : (untyped, compact: false) -> untyped
+    # : (untyped, compact: true) -> untyped
     def serialize_structured_value: (untyped, compact: false) -> untyped
+                                | (untyped, compact: true) -> untyped
 
     # Integrate structured parameter errors into parent errors
     # : (untyped, String) -> void

--- a/sig/structured_params/params.rbs
+++ b/sig/structured_params/params.rbs
@@ -74,10 +74,10 @@ module StructuredParams
     def format_error_path: (Symbol, Integer?) -> String
 
     # Serialize structured values
-    # : (untyped, compact: false) -> untyped
-    # : (untyped, compact: true) -> untyped
-    def serialize_structured_value: (untyped, compact: false) -> untyped
-                                | (untyped, compact: true) -> untyped
+    # : (bool, compact: false) -> untyped
+    # : (bool, compact: true) -> untyped
+    def serialize_structured_value: (bool, compact: false) -> untyped
+                                  | (bool, compact: true) -> untyped
 
     # Integrate structured parameter errors into parent errors
     # : (untyped, String) -> void

--- a/spec/params_spec.rb
+++ b/spec/params_spec.rb
@@ -160,7 +160,9 @@ RSpec.describe StructuredParams::Params do
   end
 
   describe '#attributes' do
-    subject(:attributes) { build(:user_parameter, **user_param_attributes).attributes(symbolize: symbolize, compact: compact) }
+    subject(:attributes) do
+      build(:user_parameter, **user_param_attributes).attributes(symbolize: symbolize, compact: compact)
+    end
 
     let(:user_param_attributes) { attributes_for(:user_parameter) }
     let(:compact) { false }

--- a/spec/params_spec.rb
+++ b/spec/params_spec.rb
@@ -160,9 +160,10 @@ RSpec.describe StructuredParams::Params do
   end
 
   describe '#attributes' do
-    subject(:attributes) { build(:user_parameter, **user_param_attributes).attributes(symbolize: symbolize) }
+    subject(:attributes) { build(:user_parameter, **user_param_attributes).attributes(symbolize: symbolize, compact: compact) }
 
     let(:user_param_attributes) { attributes_for(:user_parameter) }
+    let(:compact) { false }
 
     context 'when symbolize: false' do
       let(:symbolize) { false }
@@ -174,6 +175,88 @@ RSpec.describe StructuredParams::Params do
       let(:symbolize) { true }
 
       it { is_expected.to eq user_param_attributes.deep_symbolize_keys }
+    end
+
+    context 'with compact: true' do
+      let(:symbolize) { false }
+      let(:compact) { true }
+
+      context 'with nil values' do
+        let(:user_param_attributes) do
+          {
+            name: 'Tanaka Taro',
+            email: nil,
+            age: 30,
+            address: {
+              postal_code: '123-4567',
+              prefecture: nil,
+              city: 'Shibuya-ku',
+              street: nil
+            },
+            hobbies: [
+              { name: 'programming', level: 3, years_experience: nil },
+              { name: nil, level: 2, years_experience: 5 }
+            ],
+            tags: %w[Ruby Rails Web]
+          }
+        end
+
+        let(:expected_result) do
+          {
+            'name' => 'Tanaka Taro',
+            'age' => 30,
+            'address' => {
+              'postal_code' => '123-4567',
+              'city' => 'Shibuya-ku'
+            },
+            'hobbies' => [
+              { 'name' => 'programming', 'level' => 3 },
+              { 'level' => 2, 'years_experience' => 5 }
+            ],
+            'tags' => %w[Ruby Rails Web]
+          }
+        end
+
+        it 'removes nil values recursively' do
+          expect(attributes).to eq(expected_result)
+        end
+      end
+
+      context 'with symbolize: true and compact: true' do
+        let(:symbolize) { true }
+        let(:compact) { true }
+
+        let(:user_param_attributes) do
+          {
+            name: 'Tanaka Taro',
+            email: nil,
+            age: 30,
+            address: {
+              postal_code: '123-4567',
+              prefecture: nil,
+              city: 'Shibuya-ku',
+              street: nil
+            },
+            hobbies: nil,
+            tags: nil
+          }
+        end
+
+        let(:expected_result) do
+          {
+            name: 'Tanaka Taro',
+            age: 30,
+            address: {
+              postal_code: '123-4567',
+              city: 'Shibuya-ku'
+            }
+          }
+        end
+
+        it 'symbolizes keys and removes nil values recursively' do
+          expect(attributes).to eq(expected_result)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This pull request enhances the `StructuredParams::Params` class by introducing a new `compact` option to the `attributes` and `serialize_structured_value` methods, allowing for recursive removal of nil values from structured parameter hashes. The changes also update type signatures and add comprehensive tests to ensure correct behavior.

### Feature addition: Compact attributes

* Added a `compact` keyword argument to the `attributes` and `serialize_structured_value` methods in `lib/structured_params/params.rb`, enabling recursive removal of nil values from returned hashes. [[1]](diffhunk://#diff-c76930a543999b66eb7e0393df55884675b1e1780a9c47566cd27cd8a2f271baL76-R89) [[2]](diffhunk://#diff-c76930a543999b66eb7e0393df55884675b1e1780a9c47566cd27cd8a2f271baL154-R164)

### Type signature updates

* Updated the `attributes` and `serialize_structured_value` method signatures in `sig/structured_params/params.rbs` to reflect the new `compact` argument and its accepted combinations. [[1]](diffhunk://#diff-d74f91de00e3b103af815a23bf4cd8106a740098a8100dea20482412996e99f6L41-R48) [[2]](diffhunk://#diff-d74f91de00e3b103af815a23bf4cd8106a740098a8100dea20482412996e99f6L73-R78)

### Test coverage

* Modified and extended tests in `spec/params_spec.rb` to cover the new `compact` option, including cases with nested hashes, arrays, and symbolized keys, verifying that nil values are removed as expected. [[1]](diffhunk://#diff-91dcb85e94c369a4d1beef80d93bbb0578d66c79b13b184ec328a43da1100f85L163-R166) [[2]](diffhunk://#diff-91dcb85e94c369a4d1beef80d93bbb0578d66c79b13b184ec328a43da1100f85R179-R260)