### PR TITLE
Update attributes method signatures to use optional keyword arguments…

### DIFF
--- a/lib/structured_params/params.rb
+++ b/lib/structured_params/params.rb
@@ -73,10 +73,8 @@ module StructuredParams
     end
 
     # Convert structured objects to Hash and get attributes
-    #: (symbolize: true, compact: false) -> Hash[Symbol, untyped]
-    #: (symbolize: false, compact: false) -> Hash[String, untyped]
-    #: (symbolize: true, compact: true) -> Hash[Symbol, untyped]
-    #: (symbolize: false, compact: true) -> Hash[String, untyped]
+    #: (?symbolize: false, ?compact: bool) -> Hash[String, untyped]
+    #: (?symbolize: true, ?compact: bool) -> Hash[Symbol, untyped]
     def attributes(symbolize: false, compact: false)
       attrs = super()
 
@@ -154,8 +152,7 @@ module StructuredParams
     end
 
     # Serialize structured values
-    #: (bool, compact: false) -> untyped
-    #: (bool, compact: true) -> untyped
+    #: (bool, ?compact: bool) -> untyped
     def serialize_structured_value(value, compact: false)
       case value
       when Array

--- a/sig/structured_params/params.rbs
+++ b/sig/structured_params/params.rbs
@@ -38,14 +38,10 @@ module StructuredParams
     def errors: () -> ::StructuredParams::Errors
 
     # Convert structured objects to Hash and get attributes
-    # : (symbolize: true, compact: false) -> Hash[Symbol, untyped]
-    # : (symbolize: false, compact: false) -> Hash[String, untyped]
-    # : (symbolize: true, compact: true) -> Hash[Symbol, untyped]
-    # : (symbolize: false, compact: true) -> Hash[String, untyped]
-    def attributes: (symbolize: true, compact: false) -> Hash[Symbol, untyped]
-                  | (symbolize: false, compact: false) -> Hash[String, untyped]
-                  | (symbolize: true, compact: true) -> Hash[Symbol, untyped]
-                  | (symbolize: false, compact: true) -> Hash[String, untyped]
+    # : (?symbolize: false, ?compact: bool) -> Hash[String, untyped]
+    # : (?symbolize: true, ?compact: bool) -> Hash[Symbol, untyped]
+    def attributes: (?symbolize: false, ?compact: bool) -> Hash[String, untyped]
+                  | (?symbolize: true, ?compact: bool) -> Hash[Symbol, untyped]
 
     private
 
@@ -74,10 +70,8 @@ module StructuredParams
     def format_error_path: (Symbol, Integer?) -> String
 
     # Serialize structured values
-    # : (bool, compact: false) -> untyped
-    # : (bool, compact: true) -> untyped
-    def serialize_structured_value: (bool, compact: false) -> untyped
-                                  | (bool, compact: true) -> untyped
+    # : (bool, ?compact: bool) -> untyped
+    def serialize_structured_value: (bool, ?compact: bool) -> untyped
 
     # Integrate structured parameter errors into parent errors
     # : (untyped, String) -> void


### PR DESCRIPTION
This pull request updates the type signatures for the `attributes` and `serialize_structured_value` methods in both the implementation (`lib/structured_params/params.rb`) and the interface (`sig/structured_params/params.rbs`). The main change is to make the `compact` and `symbolize` keyword arguments optional, which improves flexibility and better matches Ruby conventions.

Type signature updates:

* Made the `compact` and `symbolize` keyword arguments optional in the `attributes` method signature in both the implementation and the RBS file, allowing callers to omit these parameters if they want default behavior. [[1]](diffhunk://#diff-c76930a543999b66eb7e0393df55884675b1e1780a9c47566cd27cd8a2f271baL76-R77) [[2]](diffhunk://#diff-d74f91de00e3b103af815a23bf4cd8106a740098a8100dea20482412996e99f6L41-R44)
* Updated the `serialize_structured_value` method signature to make the `compact` keyword argument optional in both the implementation and the RBS file. [[1]](diffhunk://#diff-c76930a543999b66eb7e0393df55884675b1e1780a9c47566cd27cd8a2f271baL157-R155) [[2]](diffhunk://#diff-d74f91de00e3b103af815a23bf4cd8106a740098a8100dea20482412996e99f6L77-R74)… in params.rb and params.rbs