### PR TITLE
Refactor `attributes` and `serialize_structured_value` methods to rep…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,6 @@ RSpec/ExampleLength:
 # ========= Metrics =========
 Metrics/ClassLength:
   Max: 150
+
+ Metrics/MethodLength:
+  Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,5 +27,5 @@ RSpec/ExampleLength:
 Metrics/ClassLength:
   Max: 150
 
- Metrics/MethodLength:
+Metrics/MethodLength:
   Max: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,5 @@
 # Changelog
 
-## [0.4.1] - 2025-09-09
-
-## What's Changed
-* Update attributes method signatures to use optional keyword arguments… by @Syati in https://github.com/Syati/structured_params/pull/8
-
-
-**Full Changelog**: https://github.com/Syati/structured_params/compare/v0.4.0...v0.4.1
-
-## [0.4.0] - 2025-09-08
-
-## What's Changed
-* Add compact option to attributes and serialize_structured_value methods by @Syati in https://github.com/Syati/structured_params/pull/7
-
-
-**Full Changelog**: https://github.com/Syati/structured_params/compare/v0.3.0...v0.4.0
-
 ## [0.3.0] - 2025-09-06
 
 ## What's Changed

--- a/sig/structured_params/params.rbs
+++ b/sig/structured_params/params.rbs
@@ -38,10 +38,10 @@ module StructuredParams
     def errors: () -> ::StructuredParams::Errors
 
     # Convert structured objects to Hash and get attributes
-    # : (?symbolize: false, ?compact: bool) -> Hash[String, untyped]
-    # : (?symbolize: true, ?compact: bool) -> Hash[Symbol, untyped]
-    def attributes: (?symbolize: false, ?compact: bool) -> Hash[String, untyped]
-                  | (?symbolize: true, ?compact: bool) -> Hash[Symbol, untyped]
+    # : (?symbolize: false, ?compact_mode: :none | :nil_only | :all_blank) -> Hash[String, untyped]
+    # : (?symbolize: true, ?compact_mode: :none | :nil_only | :all_blank) -> Hash[Symbol, untyped]
+    def attributes: (?symbolize: false, ?compact_mode: :none | :nil_only | :all_blank) -> Hash[String, untyped]
+                  | (?symbolize: true, ?compact_mode: :none | :nil_only | :all_blank) -> Hash[Symbol, untyped]
 
     private
 
@@ -70,8 +70,8 @@ module StructuredParams
     def format_error_path: (Symbol, Integer?) -> String
 
     # Serialize structured values
-    # : (bool, ?compact: bool) -> untyped
-    def serialize_structured_value: (bool, ?compact: bool) -> untyped
+    # : (untyped, ?compact_mode: :none | :nil_only | :all_blank) -> untyped
+    def serialize_structured_value: (untyped, ?compact_mode: :none | :nil_only | :all_blank) -> untyped
 
     # Integrate structured parameter errors into parent errors
     # : (untyped, String) -> void

--- a/spec/params_spec.rb
+++ b/spec/params_spec.rb
@@ -161,11 +161,11 @@ RSpec.describe StructuredParams::Params do
 
   describe '#attributes' do
     subject(:attributes) do
-      build(:user_parameter, **user_param_attributes).attributes(symbolize: symbolize, compact: compact)
+      build(:user_parameter, **user_param_attributes).attributes(symbolize: symbolize, compact_mode: compact_mode)
     end
 
     let(:user_param_attributes) { attributes_for(:user_parameter) }
-    let(:compact) { false }
+    let(:compact_mode) { :none }
 
     context 'when symbolize: false' do
       let(:symbolize) { false }
@@ -179,9 +179,9 @@ RSpec.describe StructuredParams::Params do
       it { is_expected.to eq user_param_attributes.deep_symbolize_keys }
     end
 
-    context 'with compact: true' do
+    context 'with compact_mode: :nil_only' do
       let(:symbolize) { false }
-      let(:compact) { true }
+      let(:compact_mode) { :nil_only }
 
       context 'with nil values' do
         let(:user_param_attributes) do
@@ -224,9 +224,9 @@ RSpec.describe StructuredParams::Params do
         end
       end
 
-      context 'with symbolize: true and compact: true' do
+      context 'with symbolize: true and compact_mode: :nil_only' do
         let(:symbolize) { true }
-        let(:compact) { true }
+        let(:compact_mode) { :nil_only }
 
         let(:user_param_attributes) do
           {
@@ -256,6 +256,52 @@ RSpec.describe StructuredParams::Params do
         end
 
         it 'symbolizes keys and removes nil values recursively' do
+          expect(attributes).to eq(expected_result)
+        end
+      end
+    end
+
+    context 'with compact_mode: :all_blank' do
+      let(:symbolize) { false }
+      let(:compact_mode) { :all_blank }
+
+      context 'with blank values' do
+        let(:user_param_attributes) do
+          {
+            name: 'Tanaka Taro',
+            email: '',
+            age: 30,
+            address: {
+              postal_code: '123-4567',
+              prefecture: nil,
+              city: 'Shibuya-ku',
+              street: ''
+            },
+            hobbies: [
+              { name: 'programming', level: 3, years_experience: nil },
+              { name: '', level: 2, years_experience: 5 }
+            ],
+            tags: %w[Ruby Rails Web]
+          }
+        end
+
+        let(:expected_result) do
+          {
+            'name' => 'Tanaka Taro',
+            'age' => 30,
+            'address' => {
+              'postal_code' => '123-4567',
+              'city' => 'Shibuya-ku'
+            },
+            'hobbies' => [
+              { 'name' => 'programming', 'level' => 3 },
+              { 'level' => 2, 'years_experience' => 5 }
+            ],
+            'tags' => %w[Ruby Rails Web]
+          }
+        end
+
+        it 'removes blank values (nil, empty string, etc.) recursively' do
           expect(attributes).to eq(expected_result)
         end
       end


### PR DESCRIPTION
This pull request enhances the handling of attribute serialization and compaction in `StructuredParams::Params`, making the API more flexible and expressive. The main change is replacing the previous boolean `compact` option with a new `compact_mode` keyword argument, which supports multiple modes for removing blank or nil values. The update also modifies related method signatures, updates type signatures, and adds comprehensive tests for the new behavior.

### Attribute serialization and compaction improvements

* The `attributes` and `serialize_structured_value` methods in `lib/structured_params/params.rb` now accept a `compact_mode` keyword argument (`:none`, `:nil_only`, or `:all_blank`) instead of a simple boolean `compact`. This allows more granular control over how blank or nil values are removed from serialized output. [[1]](diffhunk://#diff-c76930a543999b66eb7e0393df55884675b1e1780a9c47566cd27cd8a2f271baL76-R95) [[2]](diffhunk://#diff-c76930a543999b66eb7e0393df55884675b1e1780a9c47566cd27cd8a2f271baL155-R178)
* The Sorbet type signatures in `sig/structured_params/params.rbs` have been updated to reflect the new `compact_mode` argument and its possible values. [[1]](diffhunk://#diff-d74f91de00e3b103af815a23bf4cd8106a740098a8100dea20482412996e99f6L41-R44) [[2]](diffhunk://#diff-d74f91de00e3b103af815a23bf4cd8106a740098a8100dea20482412996e99f6L73-R74)

### Test coverage for new compaction modes

* The specs in `spec/params_spec.rb` have been updated to use `compact_mode` instead of `compact`, and new tests have been added for the `:all_blank` mode to verify recursive removal of blank values from nested structures. [[1]](diffhunk://#diff-91dcb85e94c369a4d1beef80d93bbb0578d66c79b13b184ec328a43da1100f85L164-R168) [[2]](diffhunk://#diff-91dcb85e94c369a4d1beef80d93bbb0578d66c79b13b184ec328a43da1100f85L182-R184) [[3]](diffhunk://#diff-91dcb85e94c369a4d1beef80d93bbb0578d66c79b13b184ec328a43da1100f85L227-R229) [[4]](diffhunk://#diff-91dcb85e94c369a4d1beef80d93bbb0578d66c79b13b184ec328a43da1100f85R263-R308)

### Miscellaneous updates

* The RuboCop configuration now enforces a maximum method length of 20 lines for better code quality. (`.rubocop.yml`)
* The `CHANGELOG.md` file has been cleaned up by removing outdated entries for unreleased versions.…lace `compact` boolean with `compact_mode` keyword argument, including updated specs, method signatures, and tests.