### PR TITLE
Enhance array index handling and update RBS configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,4 +31,4 @@ Metrics/ClassLength:
   Max: 150
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 25

--- a/.rubocop_rbs.yml
+++ b/.rubocop_rbs.yml
@@ -12,6 +12,7 @@ Style/RbsInline/MissingTypeAnnotation:
 Style/RbsInline/UntypedInstanceVariable:
   Exclude:
     - 'lib/structured_params/params.rb'
+    - 'lib/structured_params.rb'
 
 Style/RbsInline/RequireRbsInlineComment:
   Exclude:

--- a/Steepfile
+++ b/Steepfile
@@ -6,4 +6,9 @@ target :lib do
   signature 'sig'
 
   check 'lib'
+
+  # Suppress errors from broken library RBS files in gem_rbs_collection
+  configure_code_diagnostics do |hash|
+    hash[Steep::Diagnostic::Ruby::LibraryRBSError] = nil
+  end
 end

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,7 @@ Steps to add StructuredParams to a Rails application.
 
 - [Installation](#installation)
 - [Setup](#setup)
+- [Configuration](#configuration)
 - [Custom Type Registration](#custom-type-registration)
 
 ## Installation
@@ -36,6 +37,29 @@ StructuredParams.register_types
 ```
 
 This registers the `:object` and `:array` types with ActiveModel::Type.
+
+## Configuration
+
+You can configure StructuredParams in the same initializer:
+
+```ruby
+# config/initializers/structured_params.rb
+StructuredParams.register_types
+
+StructuredParams.configure do |config|
+  # Controls how array indices appear in human attribute names and full_messages.
+  #   0 (default) — 0-based: "Hobbies 0 Name can't be blank"
+  #   1           — 1-based: "Hobbies 1 Name can't be blank"
+  config.array_index_base = 1
+end
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `array_index_base` | `0` | Index base for array elements in error messages (`0` or `1`) |
+
+> **Note:** `array_index_base` affects `human_attribute_name` and therefore `full_messages`.
+> For APIs returning raw error keys (the typical pattern), this setting has no visible effect.
 
 ## Custom Type Registration
 

--- a/lib/structured_params.rb
+++ b/lib/structured_params.rb
@@ -54,7 +54,7 @@ module StructuredParams
 
     #: (Integer) -> void
     def array_index_base=(value)
-      raise ArgumentError, "array_index_base must be 0 or 1, got: #{value.inspect}" unless [0, 1].include?(value)
+      raise ArgumentError, "array_index_base must be 0 or 1, got: #{value.inspect}" unless value.is_a?(Integer) && [0, 1].include?(value)
 
       @array_index_base = value
     end

--- a/lib/structured_params.rb
+++ b/lib/structured_params.rb
@@ -23,17 +23,73 @@ require_relative 'structured_params/params'
 
 # Main module
 module StructuredParams
-  # Helper method to register types
-  #: () -> void
-  def self.register_types
-    ActiveModel::Type.register(:object, StructuredParams::Type::Object)
-    ActiveModel::Type.register(:array, StructuredParams::Type::Array)
+  # Global configuration for StructuredParams.
+  #
+  # == Options
+  #
+  # +array_index_base+ (Integer, default: +0+)::
+  #   Controls how array indices are displayed in human attribute names and
+  #   error messages.
+  #
+  #   * +0+ – 0-based (raw Ruby index): "Hobbies 0 Name"
+  #   * +1+ – 1-based (human-friendly): "Hobbies 1 Name"
+  #
+  # This setting applies to both API param error messages and Form Object
+  # +full_messages+.
+  #
+  # == Example
+  #
+  #   # config/initializers/structured_params.rb
+  #   StructuredParams.configure do |config|
+  #     config.array_index_base = 1   # show "1st" instead of "0th" to users
+  #   end
+  #
+  class Configuration
+    attr_reader :array_index_base #: Integer
+
+    #: () -> void
+    def initialize
+      @array_index_base = 0
+    end
+
+    #: (Integer) -> void
+    def array_index_base=(value)
+      raise ArgumentError, "array_index_base must be 0 or 1, got: #{value.inspect}" unless [0, 1].include?(value)
+
+      @array_index_base = value
+    end
   end
 
-  # Helper method to register types with custom names
-  #: (object_name: Symbol, array_name: Symbol) -> void
-  def self.register_types_as(object_name:, array_name:)
-    ActiveModel::Type.register(object_name, StructuredParams::Type::Object)
-    ActiveModel::Type.register(array_name, StructuredParams::Type::Array)
+  class << self
+    # @rbs @configuration: Configuration?
+
+    #: () -> Configuration
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    #: () { (Configuration) -> void } -> void
+    def configure
+      yield configuration
+    end
+
+    #: () -> void
+    def reset_configuration!
+      @configuration = Configuration.new
+    end
+
+    # Helper method to register types
+    #: () -> void
+    def register_types
+      ActiveModel::Type.register(:object, StructuredParams::Type::Object)
+      ActiveModel::Type.register(:array, StructuredParams::Type::Array)
+    end
+
+    # Helper method to register types with custom names
+    #: (object_name: Symbol, array_name: Symbol) -> void
+    def register_types_as(object_name:, array_name:)
+      ActiveModel::Type.register(object_name, StructuredParams::Type::Object)
+      ActiveModel::Type.register(array_name, StructuredParams::Type::Array)
+    end
   end
 end

--- a/lib/structured_params.rb
+++ b/lib/structured_params.rb
@@ -61,7 +61,7 @@ module StructuredParams
   end
 
   class << self
-    # @rbs @configuration: Configuration?
+    # @rbs self.@configuration: Configuration?
 
     #: () -> Configuration
     def configuration

--- a/lib/structured_params.rb
+++ b/lib/structured_params.rb
@@ -54,7 +54,9 @@ module StructuredParams
 
     #: (Integer) -> void
     def array_index_base=(value)
-      raise ArgumentError, "array_index_base must be 0 or 1, got: #{value.inspect}" unless value.is_a?(Integer) && [0, 1].include?(value)
+      unless value.is_a?(Integer) && [0, 1].include?(value)
+        raise ArgumentError, "array_index_base must be 0 or 1, got: #{value.inspect}"
+      end
 
       @array_index_base = value
     end

--- a/lib/structured_params/i18n.rb
+++ b/lib/structured_params/i18n.rb
@@ -22,9 +22,12 @@ module StructuredParams
   #           array:  "%{parent} %{index} 番目の%{child}"
   #           object: "%{parent}の%{child}"
   #
-  # Without these keys the defaults are:
+  # Without these keys the defaults are (with array_index_base: 0):
   #   array  → "<parent> <index> <child>"   (e.g. "Hobbies 0 Name")
   #   object → "<parent> <child>"           (e.g. "Address Postal code")
+  #
+  # With array_index_base: 1 (human-friendly):
+  #   array  → "Hobbies 1 Name"
   module I18n
     extend ActiveSupport::Concern
 
@@ -34,11 +37,11 @@ module StructuredParams
       # Flat attributes (no dot) are delegated to the default ActiveModel
       # behaviour unchanged.
       #
-      # Example (en default):
+      # Example (en default, array_index_base: 0):
       #   human_attribute_name(:'hobbies.0.name') # => "Hobbies 0 Name"
       #
-      # Example with i18n (ja):
-      #   human_attribute_name(:'hobbies.0.name') # => "趣味 0 番目の名前"
+      # Example with i18n (ja) and array_index_base: 1:
+      #   human_attribute_name(:'hobbies.0.name') # => "趣味 1 番目の名前"
       #
       #: (Symbol | String, ?Hash[untyped, untyped]) -> String
       def human_attribute_name(attribute, options = {})
@@ -99,6 +102,11 @@ module StructuredParams
       #   activemodel.errors.nested_attribute.array  (parent, index, child)
       #   activemodel.errors.nested_attribute.object (parent, child)
       #
+      # The index value passed to the i18n template is adjusted by
+      # +StructuredParams.configuration.array_index_base+:
+      #   * +0+ (default) – raw 0-based Ruby index (e.g. 0, 1, 2, …)
+      #   * +1+           – human-friendly 1-based index (e.g. 1, 2, 3, …)
+      #
       # The +locale:+ key from +options+ is forwarded to ::I18n.t so that an
       # explicit locale passed to human_attribute_name is honoured.
       #
@@ -109,12 +117,13 @@ module StructuredParams
         i18n_opts = options.slice(:locale)
 
         if index
+          display_index = index.to_i + StructuredParams.configuration.array_index_base
           ::I18n.t(
             'activemodel.errors.nested_attribute.array',
             parent: result,
-            index: index,
+            index: display_index,
             child: attr_human,
-            default: "#{result} #{index} #{attr_human}",
+            default: "#{result} #{display_index} #{attr_human}",
             **i18n_opts
           )
         else

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 14112a82013860a7d2e5246b4c4f36fbb8c349dc
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 14112a82013860a7d2e5246b4c4f36fbb8c349dc
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 14112a82013860a7d2e5246b4c4f36fbb8c349dc
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 14112a82013860a7d2e5246b4c4f36fbb8c349dc
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9bf2eebb1c54b5d6f23f2acb65d4c36f195b4783
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -50,19 +50,15 @@ gems:
   source:
     type: stdlib
 - name: bigdecimal
-  version: '3.1'
+  version: 4.1.2
   source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 14112a82013860a7d2e5246b4c4f36fbb8c349dc
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
+    type: rubygems
 - name: binding_of_caller
   version: '1.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9bf2eebb1c54b5d6f23f2acb65d4c36f195b4783
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -82,13 +78,17 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 14112a82013860a7d2e5246b4c4f36fbb8c349dc
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
-  version: '0'
+  version: '1.7'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: monitor
   version: '0'
   source:
@@ -102,15 +102,19 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 9bf2eebb1c54b5d6f23f2acb65d4c36f195b4783
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: prism
   version: 1.9.0
   source:
     type: rubygems
+- name: random-formatter
+  version: '0'
+  source:
+    type: stdlib
 - name: rspec-parameterized-core
-  version: 2.0.1
+  version: 2.0.2
   source:
     type: rubygems
 - name: rspec-parameterized-table_syntax
@@ -142,7 +146,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 14112a82013860a7d2e5246b4c4f36fbb8c349dc
+    revision: d7090c40bcea7011ad2ebaaa46bdd7d7ac3136a7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -37,4 +37,3 @@ gems:
      ignore: true
    - name: diff-lcs
      ignore: true
-

--- a/sig/structured_params.rbs
+++ b/sig/structured_params.rbs
@@ -32,7 +32,7 @@ module StructuredParams
     def array_index_base=: (Integer) -> void
   end
 
-  @configuration: Configuration?
+  self.@configuration: Configuration?
 
   # : () -> Configuration
   def self.configuration: () -> Configuration

--- a/sig/structured_params.rbs
+++ b/sig/structured_params.rbs
@@ -2,6 +2,47 @@
 
 # Main module
 module StructuredParams
+  # Global configuration for StructuredParams.
+  #
+  # == Options
+  #
+  # +array_index_base+ (Integer, default: +0+)::
+  #   Controls how array indices are displayed in human attribute names and
+  #   error messages.
+  #
+  #   * +0+ – 0-based (raw Ruby index): "Hobbies 0 Name"
+  #   * +1+ – 1-based (human-friendly): "Hobbies 1 Name"
+  #
+  # This setting applies to both API param error messages and Form Object
+  # +full_messages+.
+  #
+  # == Example
+  #
+  #   # config/initializers/structured_params.rb
+  #   StructuredParams.configure do |config|
+  #     config.array_index_base = 1   # show "1st" instead of "0th" to users
+  #   end
+  class Configuration
+    attr_reader array_index_base: Integer
+
+    # : () -> void
+    def initialize: () -> void
+
+    # : (Integer) -> void
+    def array_index_base=: (Integer) -> void
+  end
+
+  @configuration: Configuration?
+
+  # : () -> Configuration
+  def self.configuration: () -> Configuration
+
+  # : () { (Configuration) -> void } -> void
+  def self.configure: () { (Configuration) -> void } -> void
+
+  # : () -> void
+  def self.reset_configuration!: () -> void
+
   # Helper method to register types
   # : () -> void
   def self.register_types: () -> void

--- a/sig/structured_params/i18n.rbs
+++ b/sig/structured_params/i18n.rbs
@@ -21,9 +21,12 @@ module StructuredParams
   #           array:  "%{parent} %{index} 番目の%{child}"
   #           object: "%{parent}の%{child}"
   #
-  # Without these keys the defaults are:
+  # Without these keys the defaults are (with array_index_base: 0):
   #   array  → "<parent> <index> <child>"   (e.g. "Hobbies 0 Name")
   #   object → "<parent> <child>"           (e.g. "Address Postal code")
+  #
+  # With array_index_base: 1 (human-friendly):
+  #   array  → "Hobbies 1 Name"
   module I18n
     extend ActiveSupport::Concern
 
@@ -32,11 +35,11 @@ module StructuredParams
     # Flat attributes (no dot) are delegated to the default ActiveModel
     # behaviour unchanged.
     #
-    # Example (en default):
+    # Example (en default, array_index_base: 0):
     #   human_attribute_name(:'hobbies.0.name') # => "Hobbies 0 Name"
     #
-    # Example with i18n (ja):
-    #   human_attribute_name(:'hobbies.0.name') # => "趣味 0 番目の名前"
+    # Example with i18n (ja) and array_index_base: 1:
+    #   human_attribute_name(:'hobbies.0.name') # => "趣味 1 番目の名前"
     #
     # : (Symbol | String, ?Hash[untyped, untyped]) -> String
     def human_attribute_name: (Symbol | String, ?Hash[untyped, untyped]) -> String
@@ -68,6 +71,11 @@ module StructuredParams
     # Uses the i18n keys:
     #   activemodel.errors.nested_attribute.array  (parent, index, child)
     #   activemodel.errors.nested_attribute.object (parent, child)
+    #
+    # The index value passed to the i18n template is adjusted by
+    # +StructuredParams.configuration.array_index_base+:
+    #   * +0+ (default) – raw 0-based Ruby index (e.g. 0, 1, 2, …)
+    #   * +1+           – human-friendly 1-based index (e.g. 1, 2, 3, …)
     #
     # The +locale:+ key from +options+ is forwarded to ::I18n.t so that an
     # explicit locale passed to human_attribute_name is honoured.

--- a/sig/structured_params/type/array.rbs
+++ b/sig/structured_params/type/array.rbs
@@ -29,6 +29,19 @@ module StructuredParams
       def serialize: (::Array[untyped]?) -> ::Array[untyped]?
 
       # Get permitted parameter names for use with Strong Parameters
+      #
+      # Returns:
+      #   - For object arrays (value_class): nested keys from the object
+      #     Example: HobbyParams with [:name, :level]
+      #     → returns [:name, :level]
+      #     → becomes { hobbies: [:name, :level] } in Params#permit_attribute_names
+      #
+      #   - For primitive arrays (value_type): empty array
+      #     Example: attribute :tags, :array, value_type: :string
+      #     → returns []
+      #     → becomes { tags: [] } in Params#permit_attribute_names
+      #     → finally used as params.permit(:name, { tags: [] })
+      #
       # : () -> ::Array[untyped]
       def permit_attribute_names: () -> ::Array[untyped]
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -3,6 +3,9 @@
 require 'spec_helper'
 
 RSpec.describe StructuredParams::I18n do
+  # Reset global configuration after each example to avoid test pollution
+  after { StructuredParams.reset_configuration! }
+
   describe '.human_attribute_name' do
     describe 'flat attributes (without dot notation)' do
       it 'delegates to the default ActiveModel implementation' do
@@ -228,6 +231,82 @@ RSpec.describe StructuredParams::I18n do
 
       it 'resolves object attribute labels in en' do
         expect(UserParameter.human_attribute_name(:'address.postal_code', locale: :en)).to eq('Address Postal code')
+      end
+    end
+  end
+
+  describe 'StructuredParams.configuration.array_index_base' do
+    describe 'default (array_index_base: 0, 0-based)' do
+      it 'displays raw 0-based indices in the default en format' do
+        expect(UserParameter.human_attribute_name(:'hobbies.0.name')).to eq('Hobbies 0 Name')
+        expect(UserParameter.human_attribute_name(:'hobbies.2.name')).to eq('Hobbies 2 Name')
+      end
+
+      context 'with ja locale and array format key' do
+        include_context 'with ja locale'
+
+        let(:ja_overrides) do
+          { activemodel: { errors: { nested_attribute: { array: '%<parent>s %<index>s 番目の%<child>s' } } } }
+        end
+
+        it 'displays 0-based indices in the ja format' do
+          expect(UserParameter.human_attribute_name(:'hobbies.0.name')).to eq('趣味 0 番目の名前')
+          expect(UserParameter.human_attribute_name(:'hobbies.2.name')).to eq('趣味 2 番目の名前')
+        end
+      end
+    end
+
+    describe 'array_index_base: 1 (1-based, human-friendly)' do
+      before { StructuredParams.configure { |c| c.array_index_base = 1 } }
+
+      it 'adds 1 to the raw index in the default en format' do
+        # path .0. → display 1, path .2. → display 3
+        expect(UserParameter.human_attribute_name(:'hobbies.0.name')).to eq('Hobbies 1 Name')
+        expect(UserParameter.human_attribute_name(:'hobbies.2.name')).to eq('Hobbies 3 Name')
+      end
+
+      it 'applies to API param error messages as well as Form Object full_messages (same code path)' do
+        expect(UserParameter.human_attribute_name(:'hobbies.0.level')).to eq('Hobbies 1 Level')
+      end
+
+      context 'with ja locale and array format key' do
+        include_context 'with ja locale'
+
+        let(:ja_overrides) do
+          { activemodel: { errors: { nested_attribute: { array: '%<parent>s %<index>s 番目の%<child>s' } } } }
+        end
+
+        it 'displays 1-based indices in the ja format' do
+          expect(UserParameter.human_attribute_name(:'hobbies.0.name')).to eq('趣味 1 番目の名前')
+          expect(UserParameter.human_attribute_name(:'hobbies.2.name')).to eq('趣味 3 番目の名前')
+        end
+      end
+
+      context 'when locale: :ja is passed explicitly' do
+        include_context 'with ja locale'
+
+        let(:ja_overrides) do
+          { activemodel: { errors: { nested_attribute: { array: '%<parent>s %<index>s 番目の%<child>s' } } } }
+        end
+
+        it 'threads both locale option and 1-based index correctly' do
+          I18n.with_locale(:en) do
+            result = UserParameter.human_attribute_name(:'hobbies.0.name', locale: :ja)
+            expect(result).to eq('趣味 1 番目の名前')
+          end
+        end
+      end
+    end
+
+    describe 'validation of array_index_base=' do
+      it 'raises ArgumentError for values other than 0 or 1' do
+        expect { StructuredParams.configure { |c| c.array_index_base = 2 } }
+          .to raise_error(ArgumentError, /array_index_base must be 0 or 1/)
+      end
+
+      it 'raises ArgumentError for negative values' do
+        expect { StructuredParams.configure { |c| c.array_index_base = -1 } }
+          .to raise_error(ArgumentError, /array_index_base must be 0 or 1/)
       end
     end
   end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -308,6 +308,26 @@ RSpec.describe StructuredParams::I18n do
         expect { StructuredParams.configure { |c| c.array_index_base = -1 } }
           .to raise_error(ArgumentError, /array_index_base must be 0 or 1/)
       end
+
+      it 'raises ArgumentError for non-integer values (string)' do
+        expect { StructuredParams.configure { |c| c.array_index_base = '1' } }
+          .to raise_error(ArgumentError, /array_index_base must be 0 or 1/)
+      end
+
+      it 'raises ArgumentError for non-integer values (boolean)' do
+        expect { StructuredParams.configure { |c| c.array_index_base = true } }
+          .to raise_error(ArgumentError, /array_index_base must be 0 or 1/)
+      end
+
+      it 'accepts 0' do
+        expect { StructuredParams.configure { |c| c.array_index_base = 0 } }.not_to raise_error
+        expect(StructuredParams.configuration.array_index_base).to eq(0)
+      end
+
+      it 'accepts 1' do
+        expect { StructuredParams.configure { |c| c.array_index_base = 1 } }.not_to raise_error
+        expect(StructuredParams.configuration.array_index_base).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request introduces a new global configuration option to the `StructuredParams` gem, allowing users to control whether array indices in human attribute names and error messages are displayed as 0-based (default) or 1-based (human-friendly). The change is fully documented, covered by tests, and reflected in both code and type signatures. Additional improvements include minor RuboCop and type checking configuration updates, and dependency lockfile updates.

**New Configuration Option and Usage:**

* Added a `StructuredParams.configure` interface with a `array_index_base` setting (default: 0, can be set to 1) to control whether array indices in error messages and human attribute names are 0-based or 1-based. This affects both API param error messages and form object full messages. [[1]](diffhunk://#diff-a926deabc29bdb977aacc036dc4a84012aa260126cd9f2ad208783146b289e74R26-R95) [[2]](diffhunk://#diff-26f65ce162c819ea4fba6e05a3191bfc1f70456a915ed043d06d891f3d43a3c8R5-R45)
* Updated the documentation (`docs/installation.md`) to explain the new configuration option, including usage examples and option descriptions. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R9) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R41-R63)

**i18n and Human Attribute Name Behavior:**

* Modified `lib/structured_params/i18n.rb` and its type signatures to use the configured `array_index_base` when displaying array indices in human attribute names and error messages, including in i18n templates. Documentation and inline comments have been updated accordingly. [[1]](diffhunk://#diff-68b736ee664509cb841023719ff8f88a0412f7b2fa8877cbf2d1109538da8337L25-R30) [[2]](diffhunk://#diff-68b736ee664509cb841023719ff8f88a0412f7b2fa8877cbf2d1109538da8337L37-R44) [[3]](diffhunk://#diff-68b736ee664509cb841023719ff8f88a0412f7b2fa8877cbf2d1109538da8337R105-R109) [[4]](diffhunk://#diff-68b736ee664509cb841023719ff8f88a0412f7b2fa8877cbf2d1109538da8337R120-R126) [[5]](diffhunk://#diff-2ca92db76dae87dafc44db260d8541603708ba450b69e4d93098e72948ab7bf4L24-R29) [[6]](diffhunk://#diff-2ca92db76dae87dafc44db260d8541603708ba450b69e4d93098e72948ab7bf4L35-R42) [[7]](diffhunk://#diff-2ca92db76dae87dafc44db260d8541603708ba450b69e4d93098e72948ab7bf4R75-R79)
* Added comprehensive tests to ensure correct behavior for both 0-based and 1-based indices, for both default and localized (e.g., Japanese) error messages. Also tests validation of the configuration value. [[1]](diffhunk://#diff-51474a8cda735bb507e5736cdba89bde6ed714d8cd2c6ddd3bd5494c7d8de107R6-R8) [[2]](diffhunk://#diff-51474a8cda735bb507e5736cdba89bde6ed714d8cd2c6ddd3bd5494c7d8de107R237-R312)

**Type Signatures and RuboCop/Steep Configuration:**

* Updated RBS signatures to reflect the new configuration option and its API. [[1]](diffhunk://#diff-26f65ce162c819ea4fba6e05a3191bfc1f70456a915ed043d06d891f3d43a3c8R5-R45) [[2]](diffhunk://#diff-2ca92db76dae87dafc44db260d8541603708ba450b69e4d93098e72948ab7bf4L24-R29)
* Added `lib/structured_params.rb` to RuboCop RBS exclusions and increased the allowed method length in `.rubocop.yml`. Suppressed errors from broken library RBS files in `Steepfile`. [[1]](diffhunk://#diff-93ef7b302176db57655881fdc256e51fbf1e981b317c6814466036cb8da11ad4R15) [[2]](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL34-R34) [[3]](diffhunk://#diff-431712caf846de46035475ad6d3a2dafa1a4264fb5c760dc82bec8990f88486eR9-R13)

**Dependency and Lockfile Updates:**

* Updated `rbs_collection.lock.yaml` to newer gem_rbs_collection revisions and made minor dependency version adjustments. [[1]](diffhunk://#diff-365c1ef40d415fbf75d39ef4f7e5ebe496c5dc0d9303deb877202ffe6f88b37bL9-R41) [[2]](diffhunk://#diff-365c1ef40d415fbf75d39ef4f7e5ebe496c5dc0d9303deb877202ffe6f88b37bL53-R61) [[3]](diffhunk://#diff-365c1ef40d415fbf75d39ef4f7e5ebe496c5dc0d9303deb877202ffe6f88b37bL85-R91) [[4]](diffhunk://#diff-365c1ef40d415fbf75d39ef4f7e5ebe496c5dc0d9303deb877202ffe6f88b37bL105-R117) [[5]](diffhunk://#diff-365c1ef40d415fbf75d39ef4f7e5ebe496c5dc0d9303deb877202ffe6f88b37bL145-R149) [[6]](diffhunk://#diff-0282c9a5f018705f2fa02e77c0e4abcaf365b8514da68f98993fa7c1a5b36283L40)

**Other Improvements:**

* Improved documentation for `permit_attribute_names` in `Type::Array` for clarity.

These changes make StructuredParams more flexible and user-friendly, especially for applications targeting end-users who expect 1-based numbering in UI and error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global configuration for StructuredParams with array_index_base (0 or 1) to control how array indices appear in labels and error messages.

* **Documentation**
  * Installation guide updated with configuration instructions and array_index_base behavior and examples.

* **Tests**
  * Added tests covering array_index_base behavior, validation, and locale-specific labeling.

* **Chores**
  * Adjusted static analysis/type-checker and linter configurations; updated lockfile entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->